### PR TITLE
[FIX] Tag adição na DI

### DIFF
--- a/pysped/nfe/leiaute/nfe_200.py
+++ b/pysped/nfe/leiaute/nfe_200.py
@@ -1398,7 +1398,7 @@ class Adi(nfe_110.Adi):
 class DI(nfe_110.DI):
     def __init__(self):
         super(DI, self).__init__()
-
+        self.adi = []
 
 class Prod(nfe_110.Prod):
     def __init__(self):


### PR DESCRIPTION
Lá na classe DI o campo adi estava sendo iniciado com o valor [Adi()], o que acabava criando uma tag de adição vazia, como na NFe 2.00 a tag de adição não pode ser vazia, pois dentro desta tag existem campos obrigatórios, eu fiz a mudança no arquivo nfe_200.py para a tag adi iniciar com o valor [], desta forma não será criada nenhuma tag fazia de adi dentro da di.
