### PR TITLE
Stream do certificado com tempfile

### DIFF
--- a/pysped/xml_sped/certificado.py
+++ b/pysped/xml_sped/certificado.py
@@ -57,6 +57,7 @@ from time import mktime
 from OpenSSL import crypto
 from pytz import UTC
 import base64
+from uuid import uuid4
 
 
 DIRNAME = os.path.dirname(__file__)
@@ -64,6 +65,7 @@ DIRNAME = os.path.dirname(__file__)
 
 class Certificado(object):
     def __init__(self):
+        self.stream_certificado = None
         self.arquivo     = ''
         self.senha       = ''
         self.chave       = ''
@@ -78,7 +80,9 @@ class Certificado(object):
 
     def prepara_certificado_arquivo_pfx(self):
         # Lendo o arquivo pfx no formato pkcs12 como binário
-        pkcs12 = crypto.load_pkcs12(open(self.arquivo, 'rb').read(), self.senha)
+        if self.stream_certificado is None:
+            self.stream_certificado = open(self.arquivo, 'rb').read()
+        pkcs12 = crypto.load_pkcs12(self.stream_certificado, self.senha)
 
         # Retorna a string decodificada da chave privada
         self.chave = crypto.dump_privatekey(crypto.FILETYPE_PEM, pkcs12.get_privatekey())
@@ -87,7 +91,9 @@ class Certificado(object):
         self.prepara_certificado_txt(crypto.dump_certificate(crypto.FILETYPE_PEM, pkcs12.get_certificate()))
 
     def prepara_certificado_arquivo_pem(self):
-        self.prepara_certificado_txt(open(self.arquivo, 'rb').read())
+        if self.stream_certificado is None:
+            self.stream_certificado = open(self.arquivo, 'rb').read()
+        self.prepara_certificado_txt(self.stream_certificado)
 
     def prepara_certificado_txt(self, cert_txt):
         #
@@ -281,6 +287,13 @@ class Certificado(object):
     def assina_xmlnfe(self, doc):
         if not isinstance(doc, XMLNFe):
             raise ValueError('O documento nao e do tipo esperado: XMLNFe')
+
+        if self.stream_certificado:
+            caminho_temporario = '/tmp/'
+            self.arquivo = caminho_temporario + uuid4().hex
+            arq_tmp = open(self.arquivo, 'w')
+            arq_tmp.write(self.stream_certificado)
+            arq_tmp.close()
 
         # Realiza a assinatura
         xml = self.assina_xml(doc.xml)


### PR DESCRIPTION
Implementado com o uso de https://docs.python.org/2/library/tempfile.html
