### PR TITLE
[FIX] Tag NFref nao estava sendo lida corretamente

### DIFF
--- a/pysped/nfe/leiaute/nfe_110.py
+++ b/pysped/nfe/leiaute/nfe_110.py
@@ -3650,12 +3650,11 @@ class RefNF(XMLNFe):
 
     txt = property(get_txt)
 
-
-
 class NFRef(XMLNFe):
     def __init__(self):
         super(NFRef, self).__init__()
-        self.refNFe = TagCaracter(nome='refNFe', codigo='B13', tamanho=[44, 44], raiz='//NFRef', obrigatorio=False)
+        self.refNFe = TagCaracter(nome='refNFe', codigo='B13', tamanho=[44,
+                                                                        44], raiz='//NFref', obrigatorio=False)
         self.refNF  = RefNF()
 
     def get_xml(self):

--- a/pysped/nfe/leiaute/nfe_310.py
+++ b/pysped/nfe/leiaute/nfe_310.py
@@ -1669,7 +1669,7 @@ class Ide(nfe_200.Ide):
             # "reenraizadas" (propriedade raiz) para poderem ser
             # lidas corretamente
             #
-            self.NFRef = self.le_grupo('//NFe/infNFe/ide/NFref', NFRef)
+            self.NFref = self.le_grupo('//NFe/infNFe/ide/NFref', NFRef)
 
             self.tpImp.xml   = arquivo
             self.tpEmis.xml  = arquivo


### PR DESCRIPTION
Ao impotar um xml e o objeto nfe não preenchia a tag NFref, requisito obrigatorio nas notas de devolução.
