### PR TITLE
Tratamento para usar a versao 2 do SSL

### DIFF
--- a/pysped/nfe/processador_nfe.py
+++ b/pysped/nfe/processador_nfe.py
@@ -164,7 +164,11 @@ class ConexaoHTTPS(HTTPSConnection):
         if self._tunnel_host:
             self.sock = sock
             self._tunnel()
-        self.sock = ssl.wrap_socket(sock, self.key_file, self.cert_file, ssl_version=ssl.PROTOCOL_SSLv3)
+        # Tratamento para usar a versao 2 do SSL, pois a versao 3 foi removida a partir do python 2.7.9
+        try:
+            self.sock = ssl.wrap_socket(sock, self.key_file, self.cert_file, ssl_version=ssl.PROTOCOL_SSLv3)
+        except AttributeError:
+            self.sock = ssl.wrap_socket(sock, self.key_file, self.cert_file, ssl_version=ssl.PROTOCOL_SSLv23)
 
 
 class ProcessadorNFe(object):


### PR DESCRIPTION
Tratamento para usar a versao 2 do SSL, pois a versao 3 foi removida a partir do python 2.7.9