### PR TITLE
Carrega a classe ICMSTot na NF 2.00

### DIFF
--- a/pysped/nfe/leiaute/nfe_200.py
+++ b/pysped/nfe/leiaute/nfe_200.py
@@ -1802,6 +1802,7 @@ class ICMSTot(nfe_110.ICMSTot):
 class Total(nfe_110.Total):
     def __init__(self):
         super(Total, self).__init__()
+        self.ICMSTot = ICMSTot()
 
 
 class Entrega(nfe_110.Entrega):


### PR DESCRIPTION
Carrega a classe ICMSTot para pegar a classe ICMSTot da NF 2.00 que contém os novos campos de impostos aproximados da lei de transparência.
