### PR TITLE
correção da tag exporta

### DIFF
--- a/pysped/nfe/leiaute/nfe_310.py
+++ b/pysped/nfe/leiaute/nfe_310.py
@@ -49,6 +49,53 @@ import os
 DIRNAME = os.path.dirname(__file__)
 
 
+class Exporta(XMLNFe):
+    def __init__(self):
+        super(Exporta, self).__init__()
+        self.UFSaidaPais   = TagCaracter(nome='UFSaidaPais'  , codigo='ZA02', tamanho=[2,  2], raiz='//NFe/infNFe/exporta', obrigatorio=False)
+        self.xLocEmbarq = TagCaracter(nome='xLocEmbarq', codigo='ZA03', tamanho=[1, 60], raiz='//NFe/infNFe/exporta', obrigatorio=False)
+        self.xLocDespacho = TagCaracter(nome='xLocDespacho', codigo='ZA04', tamanho=[1, 60], raiz='//NFe/infNFe/exporta', obrigatorio=False)
+
+    def get_xml(self):
+        if not (self.UFSaidaPais.valor or self.xLocEmbarq.valor):
+            return ''
+
+        xml = XMLNFe.get_xml(self)
+        xml += '<exporta>'
+        xml += self.UFSaidaPais.xml
+        xml += self.xLocEmbarq.xml
+        xml += self.xLocDespacho.xml
+        xml += '</exporta>'
+        return xml
+
+    def set_xml(self, arquivo):
+        if self._le_xml(arquivo):
+            self.UFSaidaPais.xml   = arquivo
+            self.xLocEmbarq.xml = arquivo
+            self.xLocDespacho.xml = arquivo
+
+    xml = property(get_xml, set_xml)
+
+    def get_txt(self):
+        if not (self.UFSaidaPais.valor or self.xLocEmbarq.valor):
+            return ''
+
+        txt = 'ZA|'
+        txt += self.UFSaidaPais.txt + '|'
+        txt += self.xLocEmbarq.txt + '|'
+        txt += self.xLocDespacho.txt + '|'
+        txt += '\n'
+        return txt
+
+    txt = property(get_txt)
+
+
+class InfNFe(nfe_200.InfNFe):
+    def __init__(self):
+        super(InfNFe, self).__init__()
+        self.exporta  = Exporta()
+
+
 class Deduc(nfe_200.Deduc):
     def __init__(self):
         super(Deduc, self).__init__()
@@ -1112,11 +1159,6 @@ class Det(nfe_200.Det):
 class Compra(nfe_200.Compra):
     def __init__(self):
         super(Compra, self).__init__()
-
-
-class Exporta(nfe_200.Exporta):
-    def __init__(self):
-        super(Exporta, self).__init__()
 
 
 class ProcRef(nfe_200.ProcRef):

--- a/pysped/nfe/leiaute/nfe_310.py
+++ b/pysped/nfe/leiaute/nfe_310.py
@@ -53,17 +53,17 @@ class Exporta(XMLNFe):
     def __init__(self):
         super(Exporta, self).__init__()
         self.UFSaidaPais   = TagCaracter(nome='UFSaidaPais'  , codigo='ZA02', tamanho=[2,  2], raiz='//NFe/infNFe/exporta', obrigatorio=False)
-        self.xLocEmbarq = TagCaracter(nome='xLocEmbarq', codigo='ZA03', tamanho=[1, 60], raiz='//NFe/infNFe/exporta', obrigatorio=False)
+        self.xLocExporta = TagCaracter(nome='xLocExporta', codigo='ZA03', tamanho=[1, 60], raiz='//NFe/infNFe/exporta', obrigatorio=False)
         self.xLocDespacho = TagCaracter(nome='xLocDespacho', codigo='ZA04', tamanho=[1, 60], raiz='//NFe/infNFe/exporta', obrigatorio=False)
 
     def get_xml(self):
-        if not (self.UFSaidaPais.valor or self.xLocEmbarq.valor):
+        if not (self.UFSaidaPais.valor or self.xLocExporta.valor):
             return ''
 
         xml = XMLNFe.get_xml(self)
         xml += '<exporta>'
         xml += self.UFSaidaPais.xml
-        xml += self.xLocEmbarq.xml
+        xml += self.xLocExporta.xml
         xml += self.xLocDespacho.xml
         xml += '</exporta>'
         return xml
@@ -71,18 +71,18 @@ class Exporta(XMLNFe):
     def set_xml(self, arquivo):
         if self._le_xml(arquivo):
             self.UFSaidaPais.xml   = arquivo
-            self.xLocEmbarq.xml = arquivo
+            self.xLocExporta.xml = arquivo
             self.xLocDespacho.xml = arquivo
 
     xml = property(get_xml, set_xml)
 
     def get_txt(self):
-        if not (self.UFSaidaPais.valor or self.xLocEmbarq.valor):
+        if not (self.UFSaidaPais.valor or self.xLocExporta.valor):
             return ''
 
         txt = 'ZA|'
         txt += self.UFSaidaPais.txt + '|'
-        txt += self.xLocEmbarq.txt + '|'
+        txt += self.xLocExporta.txt + '|'
         txt += self.xLocDespacho.txt + '|'
         txt += '\n'
         return txt


### PR DESCRIPTION
Houve uma mudança de nome dos campos UFEmbarq para UFSaidaPais e xLocEmbarq para xLocExporta por isso foi necessário criar uma nova classe exporta para a nfe 310.
