### PR TITLE
Removido metodo de gerar DANFE duplicado

### DIFF
--- a/pysped/nfe/processador_nfe.py
+++ b/pysped/nfe/processador_nfe.py
@@ -940,11 +940,6 @@ class ProcessadorNFe(object):
                 arq.write(processo.xml.encode('utf-8'))
                 arq.close()
 
-                nome_arq = self.caminho + unicode(nfe.chave).strip().rjust(44, '0') + '.pdf'
-                arq = open(nome_arq, 'w')
-                arq.write(processo.danfe_pdf)
-                arq.close()
-
         self.caminho = caminho_original
         return processo
 


### PR DESCRIPTION
Removido do metodo montar_processo_uma_nota a geracao da DANFE porque estava duplicado, ja que no metodo gerar_danfe se a variavel salvar_arquivo estiver True o arquivo tambem pode ser gerado.